### PR TITLE
Update Omni-R1's link

### DIFF
--- a/leaderboard_data_v15_parsed.json
+++ b/leaderboard_data_v15_parsed.json
@@ -5,7 +5,7 @@
         "name": "Omni-R1",
         "size": "8.2B",
         "type": "open_access",
-        "link": "https://huggingface.co/nvidia/audio-flamingo"  
+        "link": "https://arxiv.org/abs/2505.09439v1"  
       },
       "Sound": {
         "Test-mini": "81.7",


### PR DESCRIPTION
Omni-R1's link was incorrectly set as audio-flamingo's huggingface page. Replaced it for the correct arxiv paper's link. We can further update when the code gets released.